### PR TITLE
fix: use clipboard from electron

### DIFF
--- a/lib/atom-markdown-image-paste.js
+++ b/lib/atom-markdown-image-paste.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import clipboard from 'clipboard'
+import { clipboard } from 'electron'
 import fs from 'fs'
 import { CompositeDisposable } from 'atom';
 


### PR DESCRIPTION
Fix the warning:
```
Use require("electron").clipboard instead of require("clipboard")
```