### PR TITLE
chore: update lock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,15 @@
 {
   "name": "atom-markdown-image-paste",
   "version": "0.11.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "engines": {
+        "atom": ">=1.0.0 <2.0.0"
+      }
+    }
+  }
 }


### PR DESCRIPTION
 update npm lock version to v2